### PR TITLE
Amending how customisable file sizes for attachments will work

### DIFF
--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -51,8 +51,7 @@ class UserDefinedForm extends Page {
 		'HideFieldLabels' => 'Boolean',
 		'DisplayErrorMessagesAtTop' => 'Boolean',
 		'DisableAuthenicatedFinishAction' => 'Boolean',
-		'DisableCsrfSecurityToken' => 'Boolean',
-		'CustomIndividualFileSize' => 'Int'
+		'DisableCsrfSecurityToken' => 'Boolean'
 	);
 
 	/**
@@ -209,7 +208,6 @@ SQL;
 			$export->setExportColumns($columns);
 
 			$submissions->setConfig($config);
-			$fields->addFieldToTab('Root.FormOptions', new NumericField('CustomIndividualFileSize', _t('UserDefinedForm.CustomIndividualFileSize', 'Enter in the Custom file size for indivual upload fields.')));
 			$fields->addFieldToTab('Root.Submissions', $submissions);
 			$fields->addFieldToTab('Root.FormOptions', new CheckboxField('DisableSaveSubmissions', _t('UserDefinedForm.SAVESUBMISSIONS', 'Disable Saving Submissions to Server')));
 


### PR DESCRIPTION
Amendments for original pull request as per suggestions from @tractorcow
Did not use setAllowedMaxFileSize as it is not available on FileField used the validateField method instead.
